### PR TITLE
fix character encoding for spec file

### DIFF
--- a/spec/queenshop_spec.rb
+++ b/spec/queenshop_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'spec_helper'
+# encoding: utf-8
 
 VCR.use_cassette 'queenshop' do
   describe 'check if queenshop tests pass' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'minitest/autorun'
 require 'minitest/rg'
 require 'yaml'


### PR DESCRIPTION
fix character encoding due to bug in version 1.9.3 of ruby
update the gem version to force update
